### PR TITLE
Patch: MainMemKeyValueStore

### DIFF
--- a/lib/src/store/local/main_mem_key_value.dart
+++ b/lib/src/store/local/main_mem_key_value.dart
@@ -8,7 +8,7 @@ class MainMemKeyValueStore implements KeyValueStore {
 
   /// Constructor for external use
   /// Initial values may optionally be passed in with [init].
-  MainMemKeyValueStore({Map<String, String> init}) {
+  MainMemKeyValueStore({Map<String, dynamic> init}) {
     if (init != null) _map.addAll(init);
   }
 


### PR DESCRIPTION
Patch to `MainMemKeyValueStore` (this class is mainly for testing purposes). Fixes a `null` reference error when the class is constructed without passing in a `Map` of initial values with the optional `init` named parameter`.