### PR TITLE
Patch: password field keyboard type

### DIFF
--- a/lib/src/auth/login.dart
+++ b/lib/src/auth/login.dart
@@ -88,6 +88,7 @@ class _LoginState extends State<Login> {
                   },
                 ),
               ),
+              keyboardType: TextInputType.visiblePassword,
               obscureText: !_passwordVisible,
               onFieldSubmitted: (_) => _loginPressed(context),
             ),

--- a/lib/src/auth/register.dart
+++ b/lib/src/auth/register.dart
@@ -112,6 +112,7 @@ class _RegisterState extends State<Register> {
                   },
                 ),
               ),
+              keyboardType: TextInputType.visiblePassword,
               obscureText: !_passwordVisible,
               onFieldSubmitted: (_) => _createAccountPressed(context),
             ),


### PR DESCRIPTION
Fixes a bug where the keyboard can switch to standard input mode (with autocorrect suggestions) on the password field.