### PR TITLE
Patch: fetching avatars from local cache

### DIFF
--- a/lib/src/models/user_repository.dart
+++ b/lib/src/models/user_repository.dart
@@ -81,7 +81,7 @@ class UserRepository {
         '${(await getTemporaryDirectory()).toString()}/picture/$pictureId';
     try {
       // see if the image is already stored locally
-      return File(assetDir).readAsBytes();
+      return await File(assetDir).readAsBytes();
     } catch (_) {
       return null;
     }


### PR DESCRIPTION
This patch fixes a bug where `FileNotFoundException` is not caught by `UserRepository.lookupPicLocally`, which is supposed to return `null` if the avatar is not stored locally. This was due to `UserRepositoryModel.lookupPicLocally` not `await`ing `File.readAsBytes` in the `try` block. Hence, execution left the `try` block before the exception was thrown. 

Context: when the `UserRepository` wants to fetch a user's avatar, it first checks local storage. It will only be in local storage if it has previously encountered this user and they have not changed their avatar in the meantime. Hence, `FileNotFoundException` is to be expected to be thrown by `File.readAsBytes` if this situation does not apply.