### PR TITLE
Gameplay: selectAnswer in view model

### DIFF
--- a/lib/src/models/session_model.dart
+++ b/lib/src/models/session_model.dart
@@ -441,10 +441,11 @@ class GameSessionModel extends ChangeNotifier implements AuthChange {
       answer.tfSelection = index == 0 ? false : true;
       answerQuestion();
       notifyListeners();
+    }
 
-      // MC question
-    } else if (answer.mcSelection.length <
-        (question as MCQuestion).numCorrect) {
+    // MCQ with no. selections < no. correct and answer not already selected
+    else if (answer.mcSelection.length < (question as MCQuestion).numCorrect &&
+        !answer.mcSelection.contains(index)) {
       answer.mcSelection.add(index);
       notifyListeners();
       // send answer if no. selections == no. correct


### PR DESCRIPTION
The current `toggleAnswer` has selection/deselection behaviour intended for when the user taps a selected answer in an MCQ to deselect it.

This PR adds `selectAnswer` without deselection behaviour which should be used by the class controlling the pinball.